### PR TITLE
Drop Overflow = "auto"

### DIFF
--- a/js/pagedtable.js
+++ b/js/pagedtable.js
@@ -154,7 +154,7 @@ if (!Array.prototype.map) {
 
 var pagedTableStyle = "\
 .pagedtable {\
-  overflow: auto;\
+  overflow: none;\
   padding-left: 8px;\
   padding-right: 8px;\
   color: #333;\


### PR DESCRIPTION
When paging left and right, temporarily the table is wider than the div defining the paged table, so a slider bar appears for a split second. This should drop that off.

I don't think this should impact anything else